### PR TITLE
Removed duplicate node identity generation

### DIFF
--- a/docker/app/tezos/dockerfile
+++ b/docker/app/tezos/dockerfile
@@ -7,6 +7,4 @@ EXPOSE 9732
 # P2P Mainnet
 EXPOSE 19732
 
-RUN tezos-node identity generate
-
 CMD ["tezos-node"]


### PR DESCRIPTION
The Tezos Docker image itself generates a node identity. As such, it no longer seems useful to perform identity generation upfront as part of the Nautilus scripts.