### PR TITLE
Added history mode argument to Tezos node run command

### DIFF
--- a/docker/app/tezos/dockerfile
+++ b/docker/app/tezos/dockerfile
@@ -9,4 +9,4 @@ EXPOSE 19732
 
 RUN tezos-node identity generate
 
-CMD ["tezos-node"]
+CMD ["tezos-node", "--history-mode", "archive"]


### PR DESCRIPTION
In order to keep our infrastructure running smoothly this PR runs Tezos nodes in archive mode in a hard coded manner. This could be parametrized in the future. 