### PR TITLE
Upgrade Postgres to 11.5

### DIFF
--- a/docker/app/postgres/dockerfile
+++ b/docker/app/postgres/dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:10.3-alpine
+FROM postgres:11.5-alpine
 
 ARG CONSEILDB_USER
 ARG CONSEILDB_PASSWORD


### PR DESCRIPTION
We are now standardizing around Postgres 11.5. 