### PR TITLE
Fix potential sql session issue in creating a new node

### DIFF
--- a/py-core/app/util/database_functions.py
+++ b/py-core/app/util/database_functions.py
@@ -66,6 +66,7 @@ def get_node_data(name):
 
 
 def add_node(data):
+    s = get_new_session()
     node = Node(name=data["name"],
                 arronax_port=data["arronax_port"],
                 conseil_port=data["conseil_port"],
@@ -74,8 +75,8 @@ def add_node(data):
                 history_mode=data["history_mode"],
                 status=data["status"]
                 )
-    session.add(node)
-    session.commit()
+    s.add(node)
+    s.commit()
 
 
 def get_status(name):


### PR DESCRIPTION
Adding a new node to the database did not use a new session object, which may have caused issues.
Now it does.